### PR TITLE
feat: Properly clean commit body on preparing release tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
 
       - id: "badabump"
         name: "Prepare release info"
-        run: "poetry run python -m badabump.ci prepare_release"
+        run: "poetry run python3 -m badabump.ci prepare_release \"${{ github.ref }}\""
 
       - name: "Create new release"
         uses: "actions/create-release@v1.1.4"

--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -50,9 +50,16 @@ jobs:
         name: "Run badabump"
         run: "poetry run python3 -m badabump --ci ${{ github.event.inputs.args }}"
 
+      - id: "token"
+        uses: "tibdex/github-app-token@v1.1.0"
+        with:
+          app_id: "${{ secrets.BADABUMP_APP_ID }}"
+          private_key: "${{ secrets.BADABUMP_APP_PRIVATE_KEY }}"
+
       - name: "Create pull request with changed files"
         uses: "peter-evans/create-pull-request@v3.4.1"
         with:
+          token: "${{ steps.token.outputs.token }}"
           commit-message: |
             ${{ steps.badabump.outputs.pr_title }}
 

--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   create_release_tag:
-    if: "startsWith(github.event.head_ref, 'chore/release-') && github.event.pull_request.merged == true"
+    if: "startsWith(github.head_ref, 'chore/release-') && github.event.pull_request.merged == 'true'"
     name: "Create release tag"
 
     runs-on: "ubuntu-latest"
@@ -44,8 +44,8 @@ jobs:
         run: |
           set -e
 
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name badabump-release-bot[bot]
+          git config user.email badabump-release-bot[bot]@users.noreply.github.com
 
           git tag -a ${{ steps.badabump.outputs.tag_name }} -m "${{ steps.badabump.outputs.tag_message }}"
           git push --tag

--- a/src/badabump/cleaners.py
+++ b/src/badabump/cleaners.py
@@ -1,0 +1,25 @@
+import re
+from typing import List
+
+
+CO_AUTHORED_BY = "Co-authored-by: "
+COMMIT_SUBJECT_WITH_PR_RE = re.compile(r"^(?P<subject>.+) \(\#\d+\)$")
+
+
+def clean_body(body: List[str]) -> str:
+    cleaned = "\n".join(
+        item for item in body if not item.startswith(CO_AUTHORED_BY)
+    )
+    if cleaned[-1:] == "\n":
+        return cleaned
+    return f"{cleaned}\n"
+
+
+def clean_commit_subject(value: str) -> str:
+    return COMMIT_SUBJECT_WITH_PR_RE.sub(r"\1", value)
+
+
+def clean_tag_ref(value: str) -> str:
+    if value[:10] == "refs/tags/":
+        return value[10:]
+    return value

--- a/tests/test_cleaners.py
+++ b/tests/test_cleaners.py
@@ -1,0 +1,54 @@
+import pytest
+
+from badabump.cleaners import clean_body, clean_commit_subject, clean_tag_ref
+
+
+COMMIT_BODY = """Other:
+------
+
+- More debug for release tag workflow
+- Update release workflow
+"""
+COMMIT_BODY_CO_AUTHORIZED = """Other:
+------
+
+- More debug for release tag workflow
+- Update release workflow
+
+Co-authored-by: playpauseandstop <playpauseandstop@users.noreply.github.com>
+"""
+
+COMMIT_SUBJECT = "chore: 20.1.0a2 Release"
+COMMIT_SUBJECT_WITH_PR = "chore: 20.1.0a2 Release (#5)"
+
+
+@pytest.mark.parametrize(
+    "body, expected",
+    ((COMMIT_BODY, COMMIT_BODY), (COMMIT_BODY_CO_AUTHORIZED, COMMIT_BODY)),
+)
+def test_clean_body(body, expected):
+    assert clean_body(body.splitlines()) == expected
+
+
+@pytest.mark.parametrize(
+    "subject, expected",
+    (
+        (COMMIT_SUBJECT, COMMIT_SUBJECT),
+        (COMMIT_SUBJECT_WITH_PR, COMMIT_SUBJECT),
+    ),
+)
+def test_clean_commit_subject(subject, expected):
+    assert clean_commit_subject(subject) == expected
+
+
+@pytest.mark.parametrize(
+    "ref, expected",
+    (
+        ("v20.1.0", "v20.1.0"),
+        ("release/20.1.0", "release/20.1.0"),
+        ("refs/tags/v20.1.0", "v20.1.0"),
+        ("refs/tags/release/20.1.0a0", "release/20.1.0a0"),
+    ),
+)
+def test_clean_tag_ref(ref, expected):
+    assert clean_tag_ref(ref) == expected


### PR DESCRIPTION
As well as use Badabump App for creating release PR to fix issue with not running expected checks, while creating PR via `github-actions` bot.

Also create release tag by `badabump-release-bot` user, not via `github-actions` user.