### PR TITLE
fix: Properly understand initial pre-release version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,11 @@ jobs:
         if: "matrix.python-version == env.DEV_PYTHON_VERSION"
         uses: "pre-commit/action@v2.0.0"
 
+      - name: "Setup git for test needs"
+        run: |
+          git config --global user.name badabump-release-bot[bot]
+          git config --global user.email badabump-release-bot[bot]@users.noreply.github.com
+
       - name: "Run tests"
         run: "python -m tox"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ source = ["badabump"]
 source = ["src/"]
 
 [tool.coverage.report]
-fail_under = 50
+fail_under = 75
 omit = ["src/badabump/__main__.py", "src/badabump/ci/__main__.py"]
 skip_covered = true
 show_missing = true

--- a/src/badabump/cli/commands.py
+++ b/src/badabump/cli/commands.py
@@ -4,7 +4,7 @@ from typing import Optional, Set, Tuple
 
 import toml
 
-from .output import diff, echo_message, EMPTY
+from .output import diff, echo_message
 from ..changelog import ChangeLog, in_development_header, version_header
 from ..configs import find_changelog_file, ProjectConfig
 from ..constants import (
@@ -211,14 +211,15 @@ def update_version_files(
 
     If they not specified in config, attempt to guess them automatically.
     """
+    if current_version is None:
+        return False
+
     version_files = config.version_files
     if not version_files:
         version_files = guess_version_files(config)
 
     path = config.path
-    current_version_str = (
-        current_version.format(config=config) if current_version else EMPTY
-    )
+    current_version_str = current_version.format(config=config)
     next_version_str = next_version.format(config=config)
 
     updated: Set[bool] = set()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,49 @@
+import subprocess
+from pathlib import Path
+from typing import Optional, Tuple
+
+import pytest
+
+from badabump.git import Git
+
+
+CommitTuple = Tuple[str, Optional[str], str]
+TagTuple = Tuple[str, str]
+
+
+@pytest.fixture()
+def create_git_commit():
+    def factory(path: Path, commit: str) -> None:
+        subprocess.check_call(["git", "add", "."], cwd=path)
+        subprocess.check_call(["git", "commit", "-m", commit], cwd=path)
+
+    return factory
+
+
+@pytest.fixture()
+def create_git_repository(tmpdir, create_git_commit, create_git_tag):
+    def factory(*commits: CommitTuple, tag: TagTuple = None) -> Git:
+        path = Path(tmpdir)
+
+        subprocess.check_call(["git", "init"], cwd=path)
+
+        for file_name, content, commit in commits:
+            (path / file_name).write_text(content or "")
+            create_git_commit(path, commit)
+
+        if tag is not None:
+            create_git_tag(path, *tag)
+
+        return Git(path=path)
+
+    return factory
+
+
+@pytest.fixture()
+def create_git_tag():
+    def factory(path: Path, tag: str, message: str) -> None:
+        subprocess.check_call(
+            ["git", "tag", "-a", tag, "-m", message], cwd=path
+        )
+
+    return factory

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,78 @@
+import io
+
+import pytest
+
+from badabump.cli.app import main
+from badabump.enums import ProjectTypeEnum
+
+
+PACKAGE_JSON = """{{
+    "name": "my-project",
+    "version": "{version}"
+}}
+"""
+
+PYPROJECT_TOML = """[tool.poetry]
+name = "my-project"
+version = "{version}"
+"""
+
+
+@pytest.mark.parametrize(
+    "project_type, file_name, template, version, expected",
+    (
+        (
+            ProjectTypeEnum.python,
+            "pyproject.toml",
+            PYPROJECT_TOML,
+            "20.1.0",
+            "- Initial release",
+        ),
+        (
+            ProjectTypeEnum.python,
+            "pyproject.toml",
+            PYPROJECT_TOML,
+            "20.1.0a0",
+            "- Initial pre-release",
+        ),
+        (
+            ProjectTypeEnum.javascript,
+            "package.json",
+            PACKAGE_JSON,
+            "20.1.0",
+            "- Initial release",
+        ),
+        (
+            ProjectTypeEnum.javascript,
+            "package.json",
+            PACKAGE_JSON,
+            "20.1.0-alpha.0",
+            "- Initial pre-release",
+        ),
+    ),
+)
+def test_initial_release(
+    monkeypatch,
+    create_git_repository,
+    project_type,
+    file_name,
+    template,
+    version,
+    expected,
+):
+    monkeypatch.setattr("sys.stdin", io.StringIO("y"))
+
+    content = template.format(version=version)
+    git = create_git_repository((file_name, content, "feat: Initial commit"))
+    path = git.path
+
+    main(["-C", str(path)])
+
+    assert git.retrieve_tag_subject(f"v{version}") == ""
+    assert (path / "CHANGELOG.md").exists()
+
+    changelog = (path / "CHANGELOG.md").read_text()
+    assert version in changelog
+    assert expected in changelog
+
+    assert (path / file_name).read_text() == content

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,0 +1,97 @@
+import subprocess
+
+import pytest
+
+
+COMMITS = (
+    "feat: Initial commit",
+    "feat: Add new file",
+    "docs: Add README",
+    "fix: Update implementation",
+    """build: Update to latest Python
+
+BREAKING CHANGE: Project now requires only latest Python to run.
+""",
+)
+
+
+def test_empty_repository(create_git_repository):
+    git = create_git_repository()
+    assert git.retrieve_last_tag_or_none() is None
+
+    with pytest.raises(subprocess.CalledProcessError):
+        git.retrieve_last_commit()
+
+    with pytest.raises(subprocess.CalledProcessError):
+        git.retrieve_last_tag()
+
+    git.retrieve_tag_subject("v1.0.0") == ""
+    git.retrieve_tag_body("v1.0.0") == ""
+
+
+def test_list_commits(create_git_repository):
+    git = create_git_repository(
+        ("1.txt", None, COMMITS[0]), ("2.txt", None, COMMITS[1])
+    )
+
+    commit_id = subprocess.check_output(
+        ["git", "rev-list", "--max-parents=0", "HEAD"], cwd=git.path
+    )
+    assert git.list_commits(commit_id.strip().decode("utf-8")) == (COMMITS[1],)
+
+
+def test_list_commits_empty(create_git_repository):
+    git = create_git_repository(("1.txt", None, COMMITS[0]))
+    assert git.list_commits("HEAD") == ()
+
+
+def test_retrieve_last_commit(create_git_repository):
+    git = create_git_repository(
+        ("1.txt", None, COMMITS[0]),
+        ("2.txt", None, COMMITS[1]),
+    )
+    assert git.retrieve_last_commit() == COMMITS[1]
+
+
+def test_retrieve_last_tag(create_git_repository):
+    git = create_git_repository(
+        ("1.txt", None, COMMITS[0]), tag=("v1.0.0", "1.0.0 Release")
+    )
+    assert git.retrieve_last_tag() == "v1.0.0"
+
+
+def test_retrieve_last_tag_or_none(create_git_repository):
+    git = create_git_repository(
+        ("1.txt", None, COMMITS[0]), tag=("v1.0.0", "1.0.0 Release")
+    )
+    assert git.retrieve_last_tag_or_none() == "v1.0.0"
+
+
+@pytest.mark.parametrize(
+    "message, expected_subject, expected_body",
+    (
+        ("1.0.0 Release", "1.0.0 Release", ""),
+        (
+            """1.0.0 Release
+
+Features:
+---------
+
+- Initial release
+""",
+            "1.0.0 Release",
+            """Features:
+---------
+
+- Initial release""",
+        ),
+    ),
+)
+def test_retrieve_tag_details(
+    create_git_repository, message, expected_subject, expected_body
+):
+    git = create_git_repository(
+        ("1.txt", None, COMMITS[0]), tag=("v1.0.0", message)
+    )
+    assert git.retrieve_tag_subject("v1.0.0") == expected_subject
+    assert git.retrieve_tag_body("v1.0.0") == expected_body


### PR DESCRIPTION
Ensure, when there is no tags available, properly understands pre-release version from `pyproject.toml` or `package.json`.

And if pre-release version provided there put proper message into the changelog file.

Fixes: #29
Issue: #28