### PR TITLE
test: Cover all main functionality with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@
 [![BSD License](https://img.shields.io/pypi/l/badabump.svg)](https://github.com/playpauseandstop/badabump/blob/master/LICENSE)
 [![Coverage](https://coveralls.io/repos/playpauseandstop/badabump/badge.svg?branch=master&service=github)](https://coveralls.io/github/playpauseandstop/badabump)
 
-Manage changelog and bump project version number using conventional commits from latest git tag. Support Python, JavaScript projects. Understand CalVer, SemVer version schemas. Designed to run at GitHub Actions.
+Manage changelog and bump project version number using conventional commits from latest git tag. Support Python & JavaScript projects and CalVer & SemVer schemas. Designed to run at GitHub Actions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ source = ["badabump"]
 source = ["src/"]
 
 [tool.coverage.report]
-fail_under = 85
+fail_under = 95
 omit = ["src/badabump/__main__.py", "src/badabump/ci/__main__.py"]
 skip_covered = true
 show_missing = true
@@ -18,7 +18,7 @@ show_missing = true
 [tool.poetry]
 name = "badabump"
 version = "20.1.0rc1"
-description = "Manage changelog and bump project version number using conventional commits from latest git tag. Support Python, JavaScript projects. Understand CalVer, SemVer version schemas. Designed to run at GitHub Actions."
+description = "Manage changelog and bump project version number using conventional commits from latest git tag. Support Python & JavaScript projects and CalVer & SemVer schemas. Designed to run at GitHub Actions."
 authors = ["Igor Davydenko <iam@igordavydenko.com>"]
 license = "BSD-3-Clause"
 readme = "README.md"

--- a/src/badabump/changelog.py
+++ b/src/badabump/changelog.py
@@ -171,7 +171,7 @@ class ChangeLog:
 
         def format_commits(commits: Iterator[ConventionalCommit]) -> str:
             return "\n".join(
-                f"- {item.format(format_type)}" for item in commits
+                ul_li(item.format(format_type)) for item in commits
             )
 
         features = format_block("Features:", self.feature_commits)

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1,9 +1,12 @@
+import datetime
+
 import pytest
 
 from badabump.changelog import (
     ChangeLog,
     COMMIT_TYPE_FEATURE,
     ConventionalCommit,
+    version_header,
 )
 from badabump.enums import ChangeLogTypeEnum, FormatTypeEnum
 
@@ -88,6 +91,8 @@ Other:
 
 - **BREAKING CHANGE:** Use badabump release bot for pushing tags
 - [#123] (**openapi**) Update descriptions in OpenAPI schema"""
+
+UTCNOW = datetime.datetime.utcnow()
 
 
 @pytest.mark.parametrize(
@@ -239,3 +244,75 @@ def test_commit_refactor():
     commit = ConventionalCommit.from_git_commit(REFACTOR_COMMIT)
     assert commit.commit_type == "refactor"
     assert commit.issues == ("DEV-1010",)
+
+
+@pytest.mark.parametrize(
+    "version, format_type, include_date, is_pre_release, expected",
+    (
+        (
+            "1.0.0",
+            FormatTypeEnum.markdown,
+            True,
+            False,
+            f"# 1.0.0 ({UTCNOW.date().isoformat()})",
+        ),
+        (
+            "1.0.0rc0",
+            FormatTypeEnum.markdown,
+            True,
+            True,
+            f"## 1.0.0rc0 ({UTCNOW.date().isoformat()})",
+        ),
+        (
+            "1.0.0",
+            FormatTypeEnum.markdown,
+            False,
+            False,
+            "# 1.0.0",
+        ),
+        (
+            "1.0.0rc0",
+            FormatTypeEnum.markdown,
+            False,
+            True,
+            "## 1.0.0rc0",
+        ),
+        (
+            "1.0.0",
+            FormatTypeEnum.rst,
+            True,
+            False,
+            f"1.0.0 ({UTCNOW.date().isoformat()})\n==================",
+        ),
+        (
+            "1.0.0rc0",
+            FormatTypeEnum.rst,
+            True,
+            True,
+            f"1.0.0rc0 ({UTCNOW.date().isoformat()})\n-----------------",
+        ),
+        (
+            "1.0.0",
+            FormatTypeEnum.rst,
+            False,
+            False,
+            "1.0.0\n======",
+        ),
+        (
+            "1.0.0rc0",
+            FormatTypeEnum.rst,
+            False,
+            True,
+            "1.0.0rc0\n--------",
+        ),
+    ),
+)
+def test_version_header(
+    version, format_type, include_date, is_pre_release, expected
+):
+    assert version_header(
+        version,
+        format_type,
+        include_date=include_date,
+        is_pre_release=is_pre_release,
+    )

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,0 +1,208 @@
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from badabump.cli.commands import (
+    find_changelog_path,
+    guess_version_files,
+    run_post_bump_hook,
+    update_file,
+    update_version_files,
+)
+from badabump.configs import ProjectConfig
+from badabump.enums import FormatTypeEnum, ProjectTypeEnum
+from badabump.exceptions import ConfigError
+from badabump.versions import Version
+
+
+def ensure_dir(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+@pytest.mark.parametrize(
+    "format_type, file_name",
+    (
+        (FormatTypeEnum.markdown, "CHANGELOG.md"),
+        (FormatTypeEnum.rst, "CHANGELOG.rst"),
+    ),
+)
+def test_find_changelog_path(tmpdir, format_type, file_name):
+    path = Path(tmpdir)
+    (path / file_name).write_text("# 1.0.0 Release (YYYY-MM-DD)")
+    assert (
+        find_changelog_path(
+            ProjectConfig(path=path, changelog_format_type_file=format_type)
+        )
+        == path / file_name
+    )
+
+
+@pytest.mark.parametrize(
+    "format_type, expected",
+    (
+        (FormatTypeEnum.markdown, "CHANGELOG.md"),
+        (FormatTypeEnum.rst, "CHANGELOG.rst"),
+    ),
+)
+def test_find_changelog_path_no_file(tmpdir, format_type, expected):
+    path = Path(tmpdir)
+    assert (
+        find_changelog_path(
+            ProjectConfig(path=path, changelog_format_type_file=format_type)
+        )
+        == path / expected
+    )
+
+
+def test_guess_javascript_version_files(tmpdir):
+    assert guess_version_files(
+        ProjectConfig(
+            path=Path(tmpdir), project_type=ProjectTypeEnum.javascript
+        )
+    ) == ("package.json",)
+
+
+@pytest.mark.parametrize(
+    "files, expected",
+    (
+        ((), ("pyproject.toml",)),
+        (
+            ("project.py",),
+            ("pyproject.toml", "./project.py"),
+        ),
+        (
+            ("project/__init__.py", "project/__version__.py"),
+            (
+                "pyproject.toml",
+                "./project/__init__.py",
+                "./project/__version__.py",
+            ),
+        ),
+        (
+            ("src/project/__init__.py", "src/project/__version__.py"),
+            (
+                "pyproject.toml",
+                "./src/project/__init__.py",
+                "./src/project/__version__.py",
+            ),
+        ),
+    ),
+)
+def test_guess_python_version_files(tmpdir, files, expected):
+    path = Path(tmpdir)
+
+    (path / "pyproject.toml").write_text(
+        """[tool.poetry]
+name = "project"
+version = "1.0.0"
+"""
+    )
+
+    for item in files:
+        item_path = path.joinpath(item)
+        ensure_dir(item_path.parent)
+        item_path.write_text("")
+
+    assert (
+        guess_version_files(
+            ProjectConfig(
+                path=Path(tmpdir), project_type=ProjectTypeEnum.python
+            )
+        )
+        == expected
+    )
+
+
+def test_guess_python_version_files_invalid_poetry_config(tmpdir):
+    path = Path(tmpdir)
+    (path / "pyproject.toml").write_text(
+        """[tool.poetry]
+version = "1.0.0"
+"""
+    )
+    assert guess_version_files(
+        ProjectConfig(path=path, project_type=ProjectTypeEnum.python)
+    ) == ("pyproject.toml",)
+
+
+def test_guess_python_version_files_no_pyproject_toml(tmpdir):
+    assert (
+        guess_version_files(
+            ProjectConfig(
+                path=Path(tmpdir), project_type=ProjectTypeEnum.python
+            )
+        )
+        == ()
+    )
+
+
+@pytest.mark.parametrize(
+    "file_name, expected",
+    (("package-lock.json", "npm install"), ("yarn.lock", "yarn install")),
+)
+def test_run_post_bump_hook(capsys, monkeypatch, tmpdir, file_name, expected):
+    monkeypatch.setattr("subprocess.check_call", Mock())
+
+    path = Path(tmpdir)
+    (path / file_name).write_text("")
+
+    run_post_bump_hook(
+        ProjectConfig(path=path, project_type=ProjectTypeEnum.javascript),
+        is_dry_run=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "file_name, expected",
+    (("package-lock.json", "npm install"), ("yarn.lock", "yarn install")),
+)
+def test_run_post_bump_hook_dry_run(capsys, tmpdir, file_name, expected):
+    path = Path(tmpdir)
+    (path / file_name).write_text("")
+
+    run_post_bump_hook(
+        ProjectConfig(path=path, project_type=ProjectTypeEnum.javascript),
+        is_dry_run=True,
+    )
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert expected in captured.out
+
+
+def test_update_file_does_not_exist(tmpdir):
+    assert (
+        update_file(Path(tmpdir) / "does-not-exist.txt", "one", "two") is False
+    )
+
+
+def test_update_version_files_no_current_version(tmpdir):
+    config = ProjectConfig(path=Path(tmpdir))
+    next_version = Version.from_tag("v20.1.0", config=config)
+    assert update_version_files(config, None, next_version) is False
+
+
+def test_update_version_files_with_version_files(tmpdir):
+    config = ProjectConfig(
+        path=Path(tmpdir), version_files=("pyproject.toml",)
+    )
+    current_version = Version.from_tag("v20.1.0", config=config)
+    next_version = Version.from_tag("v20.1.1", config=config)
+    assert update_version_files(config, current_version, next_version) is False
+
+
+@pytest.mark.parametrize(
+    "invalid_files", (("../pyproject.toml",), ("/tmp/pyproject.toml",))
+)
+def test_update_version_files_with_invalid_version_files(
+    tmpdir, invalid_files
+):
+    config = ProjectConfig(path=Path(tmpdir), version_files=invalid_files)
+
+    current_version = Version.from_tag("v20.1.0", config=config)
+    next_version = Version.from_tag("v20.1.1", config=config)
+
+    with pytest.raises(ConfigError):
+        update_version_files(config, current_version, next_version)


### PR DESCRIPTION
Ensure that all main `badabump` functionality covered with tests. This makes `badabump` one step closer to final `20.1.0` release, as now it can guarantee that it works as expected.

Fixes: #28