### PR TITLE
ci: Enable dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,25 @@
 version: 2
 updates:
-- package-ecosystem: pip
-  directory: "/"
-  schedule:
-    interval: monthly
-    time: "03:00"
-  open-pull-requests-limit: 25
-  reviewers:
-  - playpauseandstop
-  assignees:
-  - playpauseandstop
-  labels:
-  - build
-  allow:
-  - dependency-type: direct
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      time: "03:00"
+    open-pull-requests-limit: 25
+    reviewers:
+      - "playpauseandstop"
+    labels:
+      - "build"
+    allow:
+      - dependency-type: "direct"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      time: "05:00"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "playpauseandstop"
+    labels:
+      - "build"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,8 +110,8 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: |
-          python -m pip install coveralls==${{ env.COVERALLS_VERSION }}
-          python -m coveralls
+          python3 -m pip install coveralls==${{ env.COVERALLS_VERSION }}
+          python3 -m coveralls
 
   package:
     needs: ["test"]
@@ -128,14 +128,15 @@ jobs:
           python-version: "${{ env.DEV_PYTHON_VERSION }}"
 
       - name: "Install poetry"
+        run: "python3 -m pip install poetry==${{ env.POETRY_VERSION }}"
 
       - name: "Build package"
         run: "poetry build"
 
       - name: "Check package"
         run: |
-          python -m pip install twine==${{ env.TWINE_VERSION }}
-          python -m twine check dist/*
+          python3 -m pip install twine==${{ env.TWINE_VERSION }}
+          python3 -m twine check dist/*
 
       - name: "Publish package"
         if: "github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')"
@@ -167,6 +168,12 @@ jobs:
 
       - name: "Install poetry"
         run: "python3 -m pip install poetry==${{ env.POETRY_VERSION }}"
+
+      - name: "Cache venv"
+        uses: "actions/cache@v2.1.3"
+        with:
+          path: ".venv"
+          key: "venv-${{ hashFiles('poetry.lock') }}"
 
       - name: "Install badabump"
         run: "poetry install --no-dev"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,13 @@ jobs:
           python-version: "${{ env.DEV_PYTHON_VERSION }}"
 
       - name: "Install poetry"
-        uses: "dschep/install-poetry-action@v1.3"
+        run: "python3 -m pip install poetry==${{ env.POETRY_VERSION }}"
+
+      - name: "Cache venv"
+        uses: "actions/cache@v2.1.3"
         with:
-          version: "${{ env.POETRY_VERSION }}"
+          path: ".venv"
+          key: "venv-${{ hashFiles('poetry.lock') }}"
 
       - name: "Install package"
         run: "poetry install --no-dev"
@@ -77,16 +81,17 @@ jobs:
         with:
           python-version: "${{ matrix.python-version }}"
 
-      - name: "Install poetry"
-        uses: "dschep/install-poetry-action@v1.3"
+      - name: "Install poetry & other deps"
+        run: "python3 -m pip install poetry==${{ env.POETRY_VERSION }} tox==${{ env.TOX_VERSION }} tox-gh-actions==${{ env.TOX_GH_ACTIONS_VERSION }}"
+
+      - name: "Cache venv"
+        uses: "actions/cache@v2.1.3"
         with:
-          version: "${{ env.POETRY_VERSION }}"
+          path: ".venv"
+          key: "venv-${{ hashFiles('poetry.lock') }}"
 
       - name: "Install package"
-        run: |
-          set -e
-          poetry install --no-dev
-          python -m pip install tox==${{ env.TOX_VERSION }} tox-gh-actions==${{ env.TOX_GH_ACTIONS_VERSION }}
+        run: "poetry install --no-dev"
 
       - name: "Run pre-commit"
         if: "matrix.python-version == env.DEV_PYTHON_VERSION"
@@ -123,9 +128,6 @@ jobs:
           python-version: "${{ env.DEV_PYTHON_VERSION }}"
 
       - name: "Install poetry"
-        uses: "dschep/install-poetry-action@v1.3"
-        with:
-          version: "${{ env.POETRY_VERSION }}"
 
       - name: "Build package"
         run: "poetry build"
@@ -164,9 +166,7 @@ jobs:
           python-version: "${{ env.DEV_PYTHON_VERSION }}"
 
       - name: "Install poetry"
-        uses: "dschep/install-poetry-action@v1.3"
-        with:
-          version: "${{ env.POETRY_VERSION }}"
+        run: "python3 -m pip install poetry==${{ env.POETRY_VERSION }}"
 
       - name: "Install badabump"
         run: "poetry install --no-dev"

--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -39,9 +39,7 @@ jobs:
           python-version: "${{ env.PYTHON_VERSION }}"
 
       - name: "Install poetry"
-        uses: "dschep/install-poetry-action@v1.3"
-        with:
-          version: "${{ env.POETRY_VERSION }}"
+        run: "python3 -m pip install poetry==${{ env.POETRY_VERSION }}"
 
       - name: "Install badabump"
         run: "poetry install --no-dev"

--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -36,9 +36,7 @@ jobs:
           python-version: "${{ env.PYTHON_VERSION }}"
 
       - name: "Install poetry"
-        uses: "dschep/install-poetry-action@v1.3"
-        with:
-          version: "${{ env.POETRY_VERSION }}"
+        run: "python3 -m pip install poetry==${{ env.POETRY_VERSION }}"
 
       - name: "Install badabump"
         run: "poetry install --no-dev"


### PR DESCRIPTION
Once a month update GitHub Actions to latest versions to ensure that CI workflows using latest available versions.