### PR TITLE
fix: Support pre-releases with multiple digits

### DIFF
--- a/src/badabump/versions/pre_release.py
+++ b/src/badabump/versions/pre_release.py
@@ -21,7 +21,7 @@ SCHEMA_PARTS_FORMATTING = {
     "NUMBER": "{number}",
 }
 SCHEMA_PARTS_PARSING = {
-    "TYPE": r"(?P<type>.+)",
+    "TYPE": r"(?P<type>\D+)",
     "NUMBER": r"(?P<number>\d+)",
 }
 

--- a/tests/test_versions_pre_release.py
+++ b/tests/test_versions_pre_release.py
@@ -14,6 +14,11 @@ PRE_RELEASES: Tuple[Tuple[PreRelease, ProjectTypeEnum, str], ...] = (
         "a0",
     ),
     (
+        PreRelease(pre_release_type=PreReleaseTypeEnum.alpha, number=10),
+        ProjectTypeEnum.python,
+        "a10",
+    ),
+    (
         PreRelease(pre_release_type=PreReleaseTypeEnum.alpha, number=0),
         ProjectTypeEnum.javascript,
         "-alpha.0",
@@ -29,14 +34,29 @@ PRE_RELEASES: Tuple[Tuple[PreRelease, ProjectTypeEnum, str], ...] = (
         "-beta.1",
     ),
     (
+        PreRelease(pre_release_type=PreReleaseTypeEnum.beta, number=42),
+        ProjectTypeEnum.javascript,
+        "-beta.42",
+    ),
+    (
         PreRelease(pre_release_type=PreReleaseTypeEnum.rc, number=2),
         ProjectTypeEnum.python,
         "rc2",
     ),
     (
+        PreRelease(pre_release_type=PreReleaseTypeEnum.rc, number=15),
+        ProjectTypeEnum.python,
+        "rc15",
+    ),
+    (
         PreRelease(pre_release_type=PreReleaseTypeEnum.rc, number=2),
         ProjectTypeEnum.javascript,
         "-rc.2",
+    ),
+    (
+        PreRelease(pre_release_type=PreReleaseTypeEnum.rc, number=25),
+        ProjectTypeEnum.javascript,
+        "-rc.25",
     ),
 )
 


### PR DESCRIPTION
Previously regexp for parsing pre-releases failed for Python as there is no delimiter between pre-release type (`a`, `b`, `rc`) and version.

Cause of that change the regexp for type to expect only non-digit symbols (`\D+`) instead of expecting any symbols (`.+`)

Fixes: #64