### PR TITLE
fix: Escape backticks when setting output at GitHub Actions

### DIFF
--- a/src/badabump/cli/output.py
+++ b/src/badabump/cli/output.py
@@ -2,6 +2,13 @@ from difflib import ndiff
 
 
 EMPTY = "-"
+VALUE_ESCAPE_MAPPING = (
+    ("%", "%25"),
+    ("$", "%24"),
+    ("`", "%60"),
+    ("\n", "%0A"),
+    ("\r", "%0D"),
+)
 
 
 def diff(current_content: str, next_content: str) -> str:
@@ -27,7 +34,6 @@ def echo_value(
 
 
 def github_actions_output(name: str, value: str) -> None:
-    value = value.replace("%", "%25")
-    value = value.replace("\n", "%0A")
-    value = value.replace("\r", "%0D")
+    for symbol, code in VALUE_ESCAPE_MAPPING:
+        value = value.replace(symbol, code)
     print(f"::set-output name={name}::{value}")

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -1,0 +1,19 @@
+import pytest
+
+from badabump.cli.output import github_actions_output
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    (
+        ("Hello, world!", "Hello, world!"),
+        ("$var", "%24var"),
+        ("`pwd`", "%60pwd%60"),
+        ("Multi\nLine\nString", "Multi%0ALine%0AString"),
+        ("Multi\r\nLine\r\nString", "Multi%0D%0ALine%0D%0AString"),
+    ),
+)
+def test_github_actions_output(capsys, value, expected):
+    github_actions_output("name", value)
+    out, _ = capsys.readouterr()
+    assert out == f"::set-output name=name::{expected}\n"


### PR DESCRIPTION
Apply same logic as for escaping `%`, `\n`, `\r`, but now for escaping backticks itself.

It also might be useful to escape `$`, to avoid bash variable substitution, so add them to escape list as well.

Fixes: #63