### PR TITLE
fix: Do not escape backticks & shell vars

### DIFF
--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -52,5 +52,5 @@ jobs:
           git config user.name badabump-release-bot[bot]
           git config user.email badabump-release-bot[bot]@users.noreply.github.com
 
-          git tag -a ${{ steps.badabump.outputs.tag_name }} -m "${{ steps.badabump.outputs.tag_message }}"
+          git tag -a ${{ steps.badabump.outputs.tag_name }} -m '${{ steps.badabump.outputs.tag_message }}'
           git push --tag

--- a/src/badabump/cli/output.py
+++ b/src/badabump/cli/output.py
@@ -2,13 +2,7 @@ from difflib import ndiff
 
 
 EMPTY = "-"
-VALUE_ESCAPE_MAPPING = (
-    ("%", "%25"),
-    ("$", "%24"),
-    ("`", "%60"),
-    ("\n", "%0A"),
-    ("\r", "%0D"),
-)
+VALUE_ESCAPE_MAPPING = (("%", "%25"), ("\n", "%0A"), ("\r", "%0D"))
 
 
 def diff(current_content: str, next_content: str) -> str:

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -7,8 +7,8 @@ from badabump.cli.output import github_actions_output
     "value, expected",
     (
         ("Hello, world!", "Hello, world!"),
-        ("$var", "%24var"),
-        ("`pwd`", "%60pwd%60"),
+        ("$var", "$var"),
+        ("`pwd`", "`pwd`"),
         ("Multi\nLine\nString", "Multi%0ALine%0AString"),
         ("Multi\r\nLine\r\nString", "Multi%0D%0ALine%0D%0AString"),
     ),


### PR DESCRIPTION
But use single quotes for tag message in `release_pr` workflow.

Fixes: #63