### PR TITLE
fix: Strip spaces from commit description

### DIFF
--- a/src/badabump/changelog.py
+++ b/src/badabump/changelog.py
@@ -86,7 +86,7 @@ class ConventionalCommit:
             matched_dict = maybe_matched.groupdict()
             return cls(
                 raw_commit_type=matched_dict["commit_type"],
-                description=matched_dict["description"],
+                description=matched_dict["description"].strip(),
                 body=body_str,
             )
 

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -33,6 +33,10 @@ FIX_COMMIT_WITH_URL = f"""{FIX_COMMIT}
 Fixes: https://sentry.io/organizations/organization/issues/123456
 """
 
+FIX_COMMIT_WITH_LEADING_SPACE = "fix:  Update logic behind math operations"
+FIX_COMMIT_WITH_TRAILING_SPACE = "fix: Update logic behind math operations "
+FIX_COMMIT_WITH_BOTH_SPACES = "fix:  Update logic behind math operations "
+
 INVALID_COMMIT = "something"
 
 REFACTOR_COMMIT = """refactor: Change algorigthm to use
@@ -234,6 +238,33 @@ def test_changelog_invalid_commit_non_strict_mode():
     assert changelog.has_breaking_change is False
     assert changelog.has_minor_change is False
     assert changelog.has_micro_change is True
+
+
+@pytest.mark.parametrize(
+    "fix_commit",
+    (
+        FIX_COMMIT,
+        FIX_COMMIT_WITH_LEADING_SPACE,
+        FIX_COMMIT_WITH_TRAILING_SPACE,
+        FIX_COMMIT_WITH_BOTH_SPACES,
+    ),
+)
+def test_changelog_strip_spaces(fix_commit):
+    changelog = ChangeLog.from_git_commits(
+        [
+            FEATURE_COMMIT,
+            fix_commit,
+            CI_BREAKING_COMMIT,
+            DOCS_SCOPE_COMMIT,
+            REFACTOR_COMMIT,
+        ]
+    )
+    content = changelog.format(
+        ChangeLogTypeEnum.git_commit,
+        FormatTypeEnum.markdown,
+        is_pre_release=False,
+    )
+    assert content == CHANGELOG_GIT_MD
 
 
 def test_changelog_with_feature_commit():


### PR DESCRIPTION
If commit description contains leading and/or trailing spaces, remove them before put that description into the changelog and release notes.

Fixes: #89