### PR TITLE
build(dev-deps): Expect on local mypy to be installed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ env:
   # pip-latest-release coveralls poetry tox tox-gh-actions twine
   # ```
   COVERALLS_VERSION: "3.2.0"
-  POETRY_VERSION: "1.1.8"
-  TOX_VERSION: "3.24.3"
-  TOX_GH_ACTIONS_VERSION: "2.6.0"
+  POETRY_VERSION: "1.1.10"
+  TOX_VERSION: "3.24.4"
+  TOX_GH_ACTIONS_VERSION: "2.8.1"
   TWINE_VERSION: "3.4.2"
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,10 +92,15 @@ jobs:
       - name: "Cache venv"
         uses: "actions/cache@v2.1.6"
         with:
-          path: ".venv"
+          path: "./.venv/"
           key: "venv-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}"
 
-      - name: "Install package"
+      - name: "Install package with dev dependencies"
+        if: "startsWith(env.DEV_PYTHON_VERSION, matrix.python-version)"
+        run: "poetry install"
+
+      - name: "Install package without dev dependencies"
+        if: "not startsWith(env.DEV_PYTHON_VERSION, matrix.python-version)"
         run: "poetry install --no-dev"
 
       - name: "Run pre-commit"
@@ -147,7 +152,7 @@ jobs:
           set -euo pipefail
 
           python3 -m pip install twine==${{ env.TWINE_VERSION }}
-          python3 -m twine check dist/*
+          python3 -m twine check ./dist/*
 
       - name: "Publish package"
         if: "github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')"
@@ -187,7 +192,7 @@ jobs:
           path: ".venv"
           key: "venv-${{ env.DEV_PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}"
 
-      - name: "Install badabump"
+      - name: "Install package without dev dependencies"
         run: "poetry install --no-dev"
 
       - id: "badabump"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,15 @@ jobs:
       - name: "Cache venv"
         uses: "actions/cache@v2.1.6"
         with:
-          path: ".venv"
-          key: "venv-${{ env.DEV_PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}"
+          path: "./.venv/"
+          key: "venv-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}"
 
-      - name: "Install package"
+      - name: "Install package with dev dependencies"
+        if: "${{ startsWith(env.DEV_PYTHON_VERSION, matrix.python-version) }}"
+        run: "poetry install"
+
+      - name: "Install package without dev dependencies"
+        if: "${{ !startsWith(env.DEV_PYTHON_VERSION, matrix.python-version) }}"
         run: "poetry install --no-dev"
 
       - name: "Import package"
@@ -96,15 +101,15 @@ jobs:
           key: "venv-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}"
 
       - name: "Install package with dev dependencies"
-        if: "startsWith(env.DEV_PYTHON_VERSION, matrix.python-version)"
+        if: "${{ startsWith(env.DEV_PYTHON_VERSION, matrix.python-version) }}"
         run: "poetry install"
 
       - name: "Install package without dev dependencies"
-        if: "not startsWith(env.DEV_PYTHON_VERSION, matrix.python-version)"
+        if: "${{ !startsWith(env.DEV_PYTHON_VERSION, matrix.python-version) }}"
         run: "poetry install --no-dev"
 
       - name: "Run pre-commit"
-        if: "startsWith(env.DEV_PYTHON_VERSION, matrix.python-version)"
+        if: "${{ startsWith(env.DEV_PYTHON_VERSION, matrix.python-version) }}"
         uses: "pre-commit/action@v2.0.3"
 
       - name: "Setup git for test needs"
@@ -118,7 +123,7 @@ jobs:
         run: "python -m tox"
 
       - name: "Send report to coveralls"
-        if: "startsWith(env.DEV_PYTHON_VERSION, matrix.python-version)"
+        if: "${{ startsWith(env.DEV_PYTHON_VERSION, matrix.python-version) }}"
         run: |
           set -euo pipefail
 
@@ -155,7 +160,7 @@ jobs:
           python3 -m twine check ./dist/*
 
       - name: "Publish package"
-        if: "github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')"
+        if: "${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') }}"
         uses: "pypa/gh-action-pypi-publish@v1.4.2"
         with:
           user: "${{ secrets.PYPI_USERNAME }}"
@@ -163,7 +168,7 @@ jobs:
 
   release:
     needs: ["package"]
-    if: "startsWith(github.ref, 'refs/tags/')"
+    if: "${{ startsWith(github.ref, 'refs/tags/') }}"
     name: "Create GitHub release"
 
     runs-on: "ubuntu-latest"

--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   create_release_pr:
-    if: "github.actor == 'playpauseandstop'"
+    if: "${{ github.actor == 'playpauseandstop' }}"
     name: "Create release PR"
 
     runs-on: "ubuntu-latest"

--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   create_release_tag:
-    if: "startsWith(github.head_ref, 'chore/release-') && github.event.pull_request.merged == true"
+    if: "${{ startsWith(github.head_ref, 'chore/release-') && github.event.pull_request.merged == true }}"
     name: "Create release tag"
 
     runs-on: "ubuntu-latest"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 minimum_pre_commit_version: "1.17.0"
 repos:
   - repo: "https://github.com/commitizen-tools/commitizen"
-    rev: "v2.18.0"
+    rev: "v2.18.1"
     hooks:
       - id: "commitizen"
         # By default commitizen using `python3` instead `python` language, so
@@ -19,7 +19,7 @@ repos:
         exclude: ^docs/.*$
 
   - repo: "https://github.com/psf/black"
-    rev: "21.7b0"
+    rev: "21.9b0"
     hooks:
       - id: "black"
         # By default black using `python3` instead `python` language, so
@@ -29,13 +29,13 @@ repos:
         exclude: ^docs/.*$
 
   - repo: "https://github.com/asottile/blacken-docs"
-    rev: "v1.10.0"
+    rev: "v1.11.0"
     hooks:
       - id: "blacken-docs"
         name: "Format docs (blacken-docs)"
         args: ["-l", "64"]
         additional_dependencies:
-          - "black==21.7b0"
+          - "black==21.9b0"
 
   - repo: "https://github.com/pre-commit/pre-commit-hooks"
     rev: "v4.0.1"
@@ -54,14 +54,14 @@ repos:
         additional_dependencies: &flake8_additional_dependencies
           - "flake8==3.9.2"
           - "flake8-broken-line==0.3.0"
-          - "flake8-bugbear==21.4.3"
+          - "flake8-bugbear==21.9.1"
           - "flake8-builtins==1.5.3"
           - "flake8-comprehensions==3.6.1"
           - "flake8-eradicate==1.1.0"
           - "flake8-isort==4.0.0"
           - "flake8-mutable==1.2.0"
-          - "flake8-pie==0.14.0"
-          - "flake8-quotes==3.2.0"
+          - "flake8-pie==0.15.0"
+          - "flake8-quotes==3.3.0"
           - "flake8-string-format==0.3.0"
           - "flake8-tidy-imports==4.4.1"
           - "flake8-variables-names==0.0.4"
@@ -76,10 +76,12 @@ repos:
         additional_dependencies: *flake8_additional_dependencies
         exclude: ^docs/.*$
 
-  - repo: "https://github.com/pre-commit/mirrors-mypy"
-    rev: "v0.910"
+  - repo: "local"
     hooks:
       - id: "mypy"
         name: "Lint code (mypy)"
-        args: ["--python-executable=./.venv/bin/python3"]
-        exclude: ^docs/.*$
+        entry: "./.venv/bin/mypy"
+        language: "python"
+        "types": ["python"]
+        require_serial: true
+        exclude: ^./docs/.*$

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 	distclean \
 	install \
 	lint \
+	lint-and-test \
 	list-outdated \
 	test \
 	test-only
@@ -20,6 +21,8 @@ distclean: distclean-python
 install: install-python
 
 lint: lint-python
+
+lint-and-test: lint test
 
 list-outdated: list-outdated-python
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -68,6 +68,32 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "mypy"
+version = "0.910"
+description = "Optional static typing for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+mypy-extensions = ">=0.4.3,<0.5.0"
+toml = "*"
+typed-ast = {version = ">=1.4.0,<1.5.0", markers = "python_version < \"3.8\""}
+typing-extensions = ">=3.7.4"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+python2 = ["typed-ast (>=1.4.0,<1.5.0)"]
+
+[[package]]
+name = "mypy-extensions"
+version = "0.4.3"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "packaging"
 version = "21.0"
 description = "Core utilities for Python packages"
@@ -194,6 +220,14 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "typed-ast"
+version = "1.4.3"
+description = "a fork of Python 2 and 3 ast modules with type comment support"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "typing-extensions"
 version = "3.10.0.2"
 description = "Backported and Experimental Type Hints for Python 3.5+"
@@ -216,7 +250,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "a3bbfe028541c2c12ec68f66c0b141c9ca9faea7536ed03ce3e03464fcb51c92"
+content-hash = "d39756b37e32300ac49f687cc8816c203d8ba0b80318bc320d993ea3d9c766f1"
 
 [metadata.files]
 atomicwrites = [
@@ -229,6 +263,7 @@ attrs = [
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
+    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 coverage = [
     {file = "coverage-5.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:b6d534e4b2ab35c9f93f46229363e17f63c53ad01330df9f2d6bd1187e5eaacf"},
@@ -289,7 +324,37 @@ importlib-metadata = [
     {file = "importlib_metadata-4.8.1.tar.gz", hash = "sha256:f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1"},
 ]
 iniconfig = [
+    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
+]
+mypy = [
+    {file = "mypy-0.910-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:a155d80ea6cee511a3694b108c4494a39f42de11ee4e61e72bc424c490e46457"},
+    {file = "mypy-0.910-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:b94e4b785e304a04ea0828759172a15add27088520dc7e49ceade7834275bedb"},
+    {file = "mypy-0.910-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:088cd9c7904b4ad80bec811053272986611b84221835e079be5bcad029e79dd9"},
+    {file = "mypy-0.910-cp35-cp35m-win_amd64.whl", hash = "sha256:adaeee09bfde366d2c13fe6093a7df5df83c9a2ba98638c7d76b010694db760e"},
+    {file = "mypy-0.910-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:ecd2c3fe726758037234c93df7e98deb257fd15c24c9180dacf1ef829da5f921"},
+    {file = "mypy-0.910-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:d9dd839eb0dc1bbe866a288ba3c1afc33a202015d2ad83b31e875b5905a079b6"},
+    {file = "mypy-0.910-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:3e382b29f8e0ccf19a2df2b29a167591245df90c0b5a2542249873b5c1d78212"},
+    {file = "mypy-0.910-cp36-cp36m-win_amd64.whl", hash = "sha256:53fd2eb27a8ee2892614370896956af2ff61254c275aaee4c230ae771cadd885"},
+    {file = "mypy-0.910-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b6fb13123aeef4a3abbcfd7e71773ff3ff1526a7d3dc538f3929a49b42be03f0"},
+    {file = "mypy-0.910-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e4dab234478e3bd3ce83bac4193b2ecd9cf94e720ddd95ce69840273bf44f6de"},
+    {file = "mypy-0.910-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:7df1ead20c81371ccd6091fa3e2878559b5c4d4caadaf1a484cf88d93ca06703"},
+    {file = "mypy-0.910-cp37-cp37m-win_amd64.whl", hash = "sha256:0aadfb2d3935988ec3815952e44058a3100499f5be5b28c34ac9d79f002a4a9a"},
+    {file = "mypy-0.910-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ec4e0cd079db280b6bdabdc807047ff3e199f334050db5cbb91ba3e959a67504"},
+    {file = "mypy-0.910-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:119bed3832d961f3a880787bf621634ba042cb8dc850a7429f643508eeac97b9"},
+    {file = "mypy-0.910-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:866c41f28cee548475f146aa4d39a51cf3b6a84246969f3759cb3e9c742fc072"},
+    {file = "mypy-0.910-cp38-cp38-win_amd64.whl", hash = "sha256:ceb6e0a6e27fb364fb3853389607cf7eb3a126ad335790fa1e14ed02fba50811"},
+    {file = "mypy-0.910-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1a85e280d4d217150ce8cb1a6dddffd14e753a4e0c3cf90baabb32cefa41b59e"},
+    {file = "mypy-0.910-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:42c266ced41b65ed40a282c575705325fa7991af370036d3f134518336636f5b"},
+    {file = "mypy-0.910-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:3c4b8ca36877fc75339253721f69603a9c7fdb5d4d5a95a1a1b899d8b86a4de2"},
+    {file = "mypy-0.910-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:c0df2d30ed496a08de5daed2a9ea807d07c21ae0ab23acf541ab88c24b26ab97"},
+    {file = "mypy-0.910-cp39-cp39-win_amd64.whl", hash = "sha256:c6c2602dffb74867498f86e6129fd52a2770c48b7cd3ece77ada4fa38f94eba8"},
+    {file = "mypy-0.910-py3-none-any.whl", hash = "sha256:ef565033fa5a958e62796867b1df10c40263ea9ded87164d67572834e57a174d"},
+    {file = "mypy-0.910.tar.gz", hash = "sha256:704098302473cb31a218f1775a873b376b30b4c18229421e9e9dc8916fd16150"},
+]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
 packaging = [
     {file = "packaging-21.0-py3-none-any.whl", hash = "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"},
@@ -366,6 +431,38 @@ toml = [
 tomli = [
     {file = "tomli-1.2.1-py3-none-any.whl", hash = "sha256:8dd0e9524d6f386271a36b41dbf6c57d8e32fd96fd22b6584679dc569d20899f"},
     {file = "tomli-1.2.1.tar.gz", hash = "sha256:a5b75cb6f3968abb47af1b40c1819dc519ea82bcc065776a866e8d74c5ca9442"},
+]
+typed-ast = [
+    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:c907f561b1e83e93fad565bac5ba9c22d96a54e7ea0267c708bffe863cbe4075"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:1b3ead4a96c9101bef08f9f7d1217c096f31667617b58de957f690c92378b528"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-win32.whl", hash = "sha256:dde816ca9dac1d9c01dd504ea5967821606f02e510438120091b84e852367428"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-win_amd64.whl", hash = "sha256:777a26c84bea6cd934422ac2e3b78863a37017618b6e5c08f92ef69853e765d3"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f8afcf15cc511ada719a88e013cec87c11aff7b91f019295eb4530f96fe5ef2f"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:52b1eb8c83f178ab787f3a4283f68258525f8d70f778a2f6dd54d3b5e5fb4341"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:01ae5f73431d21eead5015997ab41afa53aa1fbe252f9da060be5dad2c730ace"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:c190f0899e9f9f8b6b7863debfb739abcb21a5c054f911ca3596d12b8a4c4c7f"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-win32.whl", hash = "sha256:398e44cd480f4d2b7ee8d98385ca104e35c81525dd98c519acff1b79bdaac363"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-win_amd64.whl", hash = "sha256:bff6ad71c81b3bba8fa35f0f1921fb24ff4476235a6e94a26ada2e54370e6da7"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0fb71b8c643187d7492c1f8352f2c15b4c4af3f6338f21681d3681b3dc31a266"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:760ad187b1041a154f0e4d0f6aae3e40fdb51d6de16e5c99aedadd9246450e9e"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5feca99c17af94057417d744607b82dd0a664fd5e4ca98061480fd8b14b18d04"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:95431a26309a21874005845c21118c83991c63ea800dd44843e42a916aec5899"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-win32.whl", hash = "sha256:aee0c1256be6c07bd3e1263ff920c325b59849dc95392a05f258bb9b259cf39c"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-win_amd64.whl", hash = "sha256:9ad2c92ec681e02baf81fdfa056fe0d818645efa9af1f1cd5fd6f1bd2bdfd805"},
+    {file = "typed_ast-1.4.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b36b4f3920103a25e1d5d024d155c504080959582b928e91cb608a65c3a49e1a"},
+    {file = "typed_ast-1.4.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:067a74454df670dcaa4e59349a2e5c81e567d8d65458d480a5b3dfecec08c5ff"},
+    {file = "typed_ast-1.4.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7538e495704e2ccda9b234b82423a4038f324f3a10c43bc088a1636180f11a41"},
+    {file = "typed_ast-1.4.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:af3d4a73793725138d6b334d9d247ce7e5f084d96284ed23f22ee626a7b88e39"},
+    {file = "typed_ast-1.4.3-cp38-cp38-win32.whl", hash = "sha256:f2362f3cb0f3172c42938946dbc5b7843c2a28aec307c49100c8b38764eb6927"},
+    {file = "typed_ast-1.4.3-cp38-cp38-win_amd64.whl", hash = "sha256:dd4a21253f42b8d2b48410cb31fe501d32f8b9fbeb1f55063ad102fe9c425e40"},
+    {file = "typed_ast-1.4.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f328adcfebed9f11301eaedfa48e15bdece9b519fb27e6a8c01aa52a17ec31b3"},
+    {file = "typed_ast-1.4.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:2c726c276d09fc5c414693a2de063f521052d9ea7c240ce553316f70656c84d4"},
+    {file = "typed_ast-1.4.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:cae53c389825d3b46fb37538441f75d6aecc4174f615d048321b716df2757fb0"},
+    {file = "typed_ast-1.4.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:b9574c6f03f685070d859e75c7f9eeca02d6933273b5e69572e5ff9d5e3931c3"},
+    {file = "typed_ast-1.4.3-cp39-cp39-win32.whl", hash = "sha256:209596a4ec71d990d71d5e0d312ac935d86930e6eecff6ccc7007fe54d703808"},
+    {file = "typed_ast-1.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:9c6d1a54552b5330bc657b7ef0eae25d00ba7ffe85d9ea8ae6540d2197a3788c"},
+    {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
 ]
 typing-extensions = [
     {file = "typing_extensions-3.10.0.2-py2-none-any.whl", hash = "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ tomli = "^1.2.0"
 
 [tool.poetry.dev-dependencies]
 coverage = {extras = ["toml"], version = "^5.5"}
+mypy = "^0.910"
 pytest = "^6.2.5"
 pytest-cov = "^2.12.1"
 time-machine = "^2.4.0"
@@ -98,7 +99,7 @@ badabump-ci = "badabump.cli.ci_app:main"
 "Bug Tracker" = "https://github.com/playpauseandstop/badabump/issues"
 
 [tool.pytest.ini_options]
-minversion = "6.2.3"
+minversion = "6.2.5"
 testpaths = ["tests/"]
 addopts = "--cov --no-cov-on-fail"
 log_level = "info"

--- a/python.mk
+++ b/python.mk
@@ -10,20 +10,25 @@
 	lint-python \
 	lint-python-only \
 	list-outdated-python \
+	poetry \
 	python-version \
 	test-python \
 	test-python-only \
 	test-python-setup \
 	test-python-teardown
 
+GIT_DIR = ./.git
+
 PYTHON_DIST_DIR = ./dist
-PYTHON_VERSION = $(shell cat .python-version)
+PYTHON_VERISON = $(shell cat .python-version)
 VENV_DIR = ./.venv
 PYTHON_BIN = $(VENV_DIR)/bin/python3
 
-LEVEL ?= dev
-POETRY ?= poetry
+STAGE ?= dev
+DOTENV ?= $(shell if [ -f ./dotenv.sh ]; then echo "./dotenv.sh "; fi)
+POETRY ?= $(DOTENV) poetry
 PRE_COMMIT ?= pre-commit
+PYTHON ?= $(DOTENV) $(PYTHON_BIN)
 
 build-python: install-python build-python-only
 build-python-only:
@@ -33,21 +38,28 @@ clean-egg-info:
 	find . \( -name *.egg-info -a -type d -not -path '$(VENV_DIR)/*' \) -exec rm -rf {} + 2> /dev/null
 
 clean-python:
-	find . \( -name __pycache__ -o -type d -empty \) -exec rm -rf {} + 2> /dev/null
+	find . \( -name __pycache__ -o -type d -empty -not -path '$(GIT_DIR)/*' \) -exec rm -rf {} + 2> /dev/null
 
 distclean-python: clean-egg-info
-	-rm -rf ./.coverage ./.install-python $(VENV_DIR)/ $(PYTHON_DIST_DIR)/
+	-rm -rf .coverage .install-python $(VENV_DIR)/ $(PYTHON_DIST_DIR)/
 
 ensure-venv: .python-version
-	if [ ! -f "$(PYTHON_BIN)" ]; then $(POETRY) env use $(PYTHON_VERSION); fi
-	if [ -f "$(PYTHON_BIN)" ]; then if [ "$$("$(PYTHON_BIN)" -V)" != "Python $(PYTHON_VERSION)" ]; then $(POETRY) env use $(PYTHON_VERSION); fi; fi
+	if [ -f "$(PYTHON_BIN)" ]; then \
+		if [ "$$("$(PYTHON_BIN)" -V)" != "Python $(PYTHON_VERISON)" ]; then \
+			echo "[python.mk] Updating virtualenv as venv version of $$("$(PYTHON_BIN)" -V) != $(PYTHON_VERISON)"; \
+			$(POETRY) env use $(PYTHON_VERISON); \
+		fi; \
+	else \
+		echo "[python.mk] Tell poetry to use Python $(PYTHON_VERISON) for creating virtual env"; \
+		$(POETRY) env use $(PYTHON_VERISON); \
+	fi
 
 install-python: .install-python
 .install-python: poetry.toml $(PYTHON_BIN) poetry.lock
 	touch $@
 
 install-python-only:
-	if [ "$(LEVEL)" = "prod" ]; then $(POETRY) install --no-dev; else $(POETRY) install; fi
+	if [ "$(STAGE)" = "prod" ]; then $(POETRY) install --no-dev; else $(POETRY) install; fi
 
 lint-python: install-python lint-python-only
 lint-python-only:
@@ -56,6 +68,9 @@ lint-python-only:
 list-outdated-python: install-python
 	$(POETRY) show -o
 
+poetry:
+	$(POETRY) $(ARGS)
+
 poetry.lock: pyproject.toml
 	@$(MAKE) -s clean-egg-info ensure-venv install-python-only
 	touch $@
@@ -63,18 +78,23 @@ poetry.lock: pyproject.toml
 poetry.toml:
 	$(POETRY) config --local virtualenvs.create true
 	$(POETRY) config --local virtualenvs.in-project true
+	@version="$(PYTHON_VERISON)"; if [ "$${version:0:4}" = "3.10" ]; then $(POETRY) config --local experimental.new-installer false; fi
 
 python-version:
-	@echo "Expected: Python $(PYTHON_VERSION)"
+	@echo "Expected: Python $(PYTHON_VERISON)"
 	@if [ -f "$(PYTHON_BIN)" ]; then echo "Virtual env: $$("$(PYTHON_BIN)" -V)"; else echo "Virtual env: -"; fi
 
-test-python: install-python lint-python clean-python test-python-only
+test-python: install-python clean-python test-python-only
 
+test-python-only: STAGE = test
 test-python-only: test-python-setup
-	$(PYTHON_BIN) -m pytest
+	STAGE=$(STAGE) $(PYTHON) -m pytest
 	@$(MAKE) -s test-python-teardown
 
+test-python-setup: STAGE = test
 test-python-setup:
+
+test-python-teardown: STAGE = test
 test-python-teardown:
 
 $(PYTHON_BIN): .python-version poetry.lock


### PR DESCRIPTION
Install `mypy` as project dev dependency to ensure that all other `types-*` library will be properly found by it.

As result also bump pre-commit hooks and update python Makefile targets.