### PR TITLE
ci: Take care of single quotes in tag message

### DIFF
--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -60,5 +60,9 @@ jobs:
           git config user.name badabump-release-bot[bot]
           git config user.email badabump-release-bot[bot]@users.noreply.github.com
 
-          git tag -a ${{ steps.badabump.outputs.tag_name }} -m '${{ steps.badabump.outputs.tag_message }}'
+          cat > ./tag_message.txt <<EOF
+          ${{ steps.badabump.outputs.tag_message }}
+          EOF
+
+          git tag -a ${{ steps.badabump.outputs.tag_name }} -F ./tag_message.txt
           git push --tag


### PR DESCRIPTION
Update `release_tag` workflow to take care of single quotes in tag message by passing tag message via `-F` flag instead of `-m`.

Fixes: #85