### PR TITLE
build: Explicitly add Python 3.10 classifier to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,10 @@ classifiers = [
   "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
+  # Classifier below need to added manually to classifiers list due to
+  # https://github.com/python-poetry/poetry/issues/4581 issue, when using
+  # stable poetry
+  "Programming Language :: Python :: 3.10",
   "Topic :: Software Development",
   "Topic :: Utilities",
   "Typing :: Typed"


### PR DESCRIPTION
At a moment `poetry@1.1.10` does not automatically add the classifier into wheel metadata, even when run on python 3.10.0rc2, which is used at GitHub Actions for publishing `badabump` into PyPI.

Related: https://github.com/python-poetry/poetry/issues/4581