### PR TITLE
ci: Fix saving tag message to file in release tag workflow

### DIFF
--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -53,16 +53,18 @@ jobs:
         name: "Run badabump"
         run: "poetry run python3 -m badabump.ci prepare_tag"
 
+      - name: "Save tag message into the file"
+        run: |
+          with open("./tag_message.txt", "w+") as handler:
+              handler.write("""${{ steps.badabump.outputs.tag_message }}""")
+        shell: "python"
+
       - name: "Create release tag from latest commit"
         run: |
           set -euo pipefail
 
           git config user.name badabump-release-bot[bot]
           git config user.email badabump-release-bot[bot]@users.noreply.github.com
-
-          cat > ./tag_message.txt <<EOF
-          ${{ steps.badabump.outputs.tag_message }}
-          EOF
 
           git tag -a ${{ steps.badabump.outputs.tag_name }} -F ./tag_message.txt
           git push --tag


### PR DESCRIPTION
Instead of saving `tag_message` output into `tag_message.txt` before calling `git tag` in bash shell, save that content using python shell, which results in "ignoring" backticks commands as for Python that will be just a string.