### PR TITLE
ci: Update default branch name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,10 @@ name: "CI"
 
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
     tags: ["v*"]
   pull_request:
-    branches: ["master"]
+    branches: ["main"]
 
 env:
   # Get latest versions by running,

--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: "actions/checkout@v3.0.2"
         with:
-          ref: "master"
+          ref: "main"
 
       - name: "Fetch git tags"
         run: |

--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: "actions/checkout@v3.0.2"
         with:
           token: "${{ steps.token.outputs.token }}"
-          ref: "master"
+          ref: "main"
 
       - name: "Install Python"
         uses: "actions/setup-python@v4.0.0"

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Latest Version](https://img.shields.io/pypi/v/badabump.svg)](https://pypi.org/project/badabump/)
 [![Python Versions](https://img.shields.io/pypi/pyversions/badabump.svg)](https://pypi.org/project/badabump/)
-[![BSD License](https://img.shields.io/pypi/l/badabump.svg)](https://github.com/playpauseandstop/badabump/blob/master/LICENSE)
-[![Coverage](https://coveralls.io/repos/playpauseandstop/badabump/badge.svg?branch=master&service=github)](https://coveralls.io/github/playpauseandstop/badabump)
+[![BSD License](https://img.shields.io/pypi/l/badabump.svg)](https://github.com/playpauseandstop/badabump/blob/main/LICENSE)
+[![Coverage](https://coveralls.io/repos/playpauseandstop/badabump/badge.svg?branch=main&service=github)](https://coveralls.io/github/playpauseandstop/badabump)
 
 Manage changelog and bump project version number using conventional commits from latest git tag. Support Python & JavaScript projects and CalVer & SemVer schemas. Designed to run at GitHub Actions.
 


### PR DESCRIPTION
To use `main` instead of `master` in CI configs & docs.