### PR TITLE
feat(changelog): Do not duplicate same commit messages

### DIFF
--- a/src/badabump/changelog.py
+++ b/src/badabump/changelog.py
@@ -202,14 +202,16 @@ class ChangeLog:
             return "\n\n".join((header, items))
 
         def format_commits(commits: Iterator[ConventionalCommit]) -> str:
-            return "\n".join(
-                ul_li(
-                    item.format(
-                        format_type, ignore_footer_urls=ignore_footer_urls
-                    )
+            formatted_commits = []
+            for commit in commits:
+                formatted_commit = commit.format(
+                    format_type, ignore_footer_urls=ignore_footer_urls
                 )
-                for item in commits
-            )
+                if formatted_commit in formatted_commits:
+                    continue
+                formatted_commits.append(formatted_commit)
+
+            return "\n".join(ul_li(item) for item in formatted_commits)
 
         features = format_block("Features:", self.feature_commits)
         fixes = format_block("Fixes:", self.fix_commits)

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -23,7 +23,7 @@ FEATURE_COMMIT = """feat: Export necessary types from the package (#31)
 - Export types, enums, utils, themes
 - Update components to use styled-components ThemeProvider
 
-Issue: IFXND-55
+Issue: DEV-55
 """
 
 FIX_COMMIT = "fix: Update logic behind math operations"
@@ -48,7 +48,7 @@ CHANGELOG_EMPTY = "No changes since last pre-release"
 
 CHANGELOG_FILE_MD = """## Features:
 
-- [IFXND-55] Export necessary types from the package (#31)
+- [DEV-55] Export necessary types from the package (#31)
 
 ## Fixes:
 
@@ -65,7 +65,7 @@ CHANGELOG_FILE_MD = """## Features:
 
 CHANGELOG_FILE_MD_PRE = """### Features:
 
-- [IFXND-55] Export necessary types from the package (#31)
+- [DEV-55] Export necessary types from the package (#31)
 
 ### Fixes:
 
@@ -82,7 +82,7 @@ CHANGELOG_FILE_MD_PRE = """### Features:
 
 CHANGELOG_FILE_RST = CHANGELOG_GIT_RST = """**Features:**
 
-- [IFXND-55] Export necessary types from the package (#31)
+- [DEV-55] Export necessary types from the package (#31)
 
 **Fixes:**
 
@@ -100,7 +100,7 @@ CHANGELOG_FILE_RST = CHANGELOG_GIT_RST = """**Features:**
 CHANGELOG_GIT_MD = """Features:
 ---------
 
-- [IFXND-55] Export necessary types from the package (#31)
+- [DEV-55] Export necessary types from the package (#31)
 
 Fixes:
 ------
@@ -119,6 +119,10 @@ Other:
 - [#123] (**openapi**) Update descriptions in OpenAPI schema"""
 
 UTCNOW = datetime.datetime.utcnow()
+
+
+def test_changelog_duplicate_commits_with_prs():
+    ...
 
 
 @pytest.mark.parametrize(
@@ -163,7 +167,10 @@ def test_changelog_format_file(format_type, is_pre_release, expected):
             FEATURE_COMMIT,
             FIX_COMMIT,
             CI_BREAKING_COMMIT,
+            REFACTOR_COMMIT,
             DOCS_SCOPE_COMMIT,
+            REFACTOR_COMMIT,
+            CI_BREAKING_COMMIT,
             REFACTOR_COMMIT,
         ]
     )
@@ -320,18 +327,18 @@ def test_commit_feature():
         commit.description == "Export necessary types from the package (#31)"
     )
     assert commit.is_breaking_change is False
-    assert commit.issues == ("IFXND-55",)
+    assert commit.issues == ("DEV-55",)
     assert (
         commit.body
         == """- Export types, enums, utils, themes
 - Update components to use styled-components ThemeProvider
 
-Issue: IFXND-55"""
+Issue: DEV-55"""
     )
     assert commit.scope is None
     assert (
         commit.format(FormatTypeEnum.markdown)
-        == "[IFXND-55] Export necessary types from the package (#31)"
+        == "[DEV-55] Export necessary types from the package (#31)"
     )
     assert commit.format(FormatTypeEnum.markdown) == commit.format(
         FormatTypeEnum.rst


### PR DESCRIPTION
When producing changelog. So, if release has 2 or more similar commit messages, only first one will be shown in changelog.

Issue: #189