### PR TITLE
fix: Fix guessing project files for python projest with dashes in names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,3 +30,7 @@ test: install clean test-only
 .PHONY: test-only
 test-only:
 	TOXENV=$(TOXENV) $(TOX)
+
+.PHONY: test-%
+test-%: install clean
+	TOXENV=$(subst test-,,$@) $(TOX)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,7 @@ commands =
   git config init.defaultBranch
   git config user.name
   git config user.email
-  python3 -m pytest
+  python3 -m pytest {tty:--color=yes}
 
 [testenv:py310-minimum-requirements]
 commands_pre =

--- a/src/badabump/cli/ci_app.py
+++ b/src/badabump/cli/ci_app.py
@@ -100,7 +100,7 @@ def prepare_tag(args: argparse.Namespace, *, config: ProjectConfig) -> int:
 
 
 def main(argv: Union[Argv, None] = None) -> int:
-    args = parse_args(argv or sys.argv[1:])
+    args = parse_args(argv if argv is not None else sys.argv[1:])
     # TODO: Fix this by providing required flag on adding subparsers
     if getattr(args, "func", None) is None:
         print(

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -69,23 +69,23 @@ def test_guess_javascript_version_files(tmpdir):
     (
         ((), ("pyproject.toml",)),
         (
-            ("project.py",),
-            ("pyproject.toml", "./project.py"),
+            ("my_project.py",),
+            ("pyproject.toml", "my_project.py"),
         ),
         (
-            ("project/__init__.py", "project/__version__.py"),
+            ("my_project/__init__.py", "my_project/__version__.py"),
             (
                 "pyproject.toml",
-                "./project/__init__.py",
-                "./project/__version__.py",
+                "my_project/__init__.py",
+                "my_project/__version__.py",
             ),
         ),
         (
-            ("src/project/__init__.py", "src/project/__version__.py"),
+            ("src/my-project/__init__.py", "src/my-project/__version__.py"),
             (
                 "pyproject.toml",
-                "./src/project/__init__.py",
-                "./src/project/__version__.py",
+                "src/my-project/__init__.py",
+                "src/my-project/__version__.py",
             ),
         ),
     ),
@@ -95,7 +95,7 @@ def test_guess_python_version_files(tmpdir, files, expected):
 
     (path / "pyproject.toml").write_text(
         """[tool.poetry]
-name = "project"
+name = "my-project"
 version = "1.0.0"
 """
     )
@@ -107,9 +107,7 @@ version = "1.0.0"
 
     assert (
         guess_version_files(
-            ProjectConfig(
-                path=Path(tmpdir), project_type=ProjectTypeEnum.python
-            )
+            ProjectConfig(path=path, project_type=ProjectTypeEnum.python)
         )
         == expected
     )


### PR DESCRIPTION
When `pyproject.toml` contain project name with dashes, such as
`aiohttp-middlewares`, try to find version files in `aiohttp_middlewares/`
directory next to `pyproject.toml` file or within `src/` directory.

Fixes: #114
