### PR TITLE
refactor(ci)!: Change output at GitHub Actions

### DIFF
--- a/src/badabump/cli/output.py
+++ b/src/badabump/cli/output.py
@@ -1,9 +1,9 @@
+import os
 from difflib import ndiff
 from typing import Union
 
 
 EMPTY = "-"
-VALUE_ESCAPE_MAPPING = (("%", "%25"), ("\n", "%0A"), ("\r", "%0D"))
 
 
 def diff(current_content: str, next_content: str) -> str:
@@ -33,6 +33,7 @@ def echo_value(
 
 
 def github_actions_output(name: str, value: str) -> None:
-    for symbol, code in VALUE_ESCAPE_MAPPING:
-        value = value.replace(symbol, code)
-    print(f"::set-output name={name}::{value}")
+    with open(os.environ["GITHUB_OUTPUT"], "a+") as github_output_handler:
+        github_output_handler.write(f"{name}<<EOF\n")
+        github_output_handler.write(value)
+        github_output_handler.write("\nEOF\n")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,13 @@ CommitTuple = Tuple[str, Union[str, None], str]
 TagTuple = Tuple[str, str]
 
 
-@pytest.fixture()
+@pytest.fixture(scope="function", autouse=True)
+def setup_github_output_env_var(monkeypatch, github_output_path):
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output_path))
+    yield
+
+
+@pytest.fixture(scope="function")
 def create_git_commit():
     def factory(path: Path, commit: str) -> None:
         subprocess.check_call(["git", "add", "."], cwd=path)
@@ -20,7 +26,7 @@ def create_git_commit():
     return factory
 
 
-@pytest.fixture()
+@pytest.fixture(scope="function")
 def create_git_repository(tmpdir, create_git_commit, create_git_tag):
     def factory(*commits: CommitTuple, tag: TagTuple = None) -> Git:
         path = Path(tmpdir)
@@ -39,7 +45,7 @@ def create_git_repository(tmpdir, create_git_commit, create_git_tag):
     return factory
 
 
-@pytest.fixture()
+@pytest.fixture(scope="function")
 def create_git_tag():
     def factory(path: Path, tag: str, message: str) -> None:
         subprocess.check_call(
@@ -47,3 +53,11 @@ def create_git_tag():
         )
 
     return factory
+
+
+@pytest.fixture(scope="function")
+def github_output_path(tmp_path) -> Path:
+    path = Path(tmp_path) / "github-output.txt"
+    if not path.exists():
+        path.write_text("")
+    return path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -85,6 +85,7 @@ def test_ci_output(
     capsys,
     create_git_commit,
     create_git_repository,
+    github_output_path,
     file_name,
     content,
     version,
@@ -102,11 +103,13 @@ def test_ci_output(
     assert main(["-C", str(path), "--ci"]) == 0
 
     captured = capsys.readouterr()
+    assert captured.out != ""
     assert captured.err == ""
 
-    assert f"::set-output name=current_tag::v{version}" in captured.out
-    assert f"::set-output name=current_version::{version}" in captured.out
-    assert f"::set-output name=next_version::{next_version}" in captured.out
+    github_output = github_output_path.read_text()
+    assert f"current_tag<<EOF\nv{version}\nEOF\n" in github_output
+    assert f"current_version<<EOF\n{version}\nEOF\n" in github_output
+    assert f"next_version<<EOF\n{next_version}\n" in github_output
 
     changelog = (path / "CHANGELOG.md").read_text()
     assert f"# {next_version}" in changelog

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -9,11 +9,17 @@ from badabump.cli.output import github_actions_output
         ("Hello, world!", "Hello, world!"),
         ("$var", "$var"),
         ("`pwd`", "`pwd`"),
-        ("Multi\nLine\nString", "Multi%0ALine%0AString"),
-        ("Multi\r\nLine\r\nString", "Multi%0D%0ALine%0D%0AString"),
+        ("Multi\nLine\nString", "Multi\nLine\nString"),
+        ("Multi\r\nLine\r\nString", "Multi\nLine\nString"),
     ),
 )
-def test_github_actions_output(capsys, value, expected):
+def test_github_actions_output(capsys, github_output_path, value, expected):
     github_actions_output("name", value)
-    out, _ = capsys.readouterr()
-    assert out == f"::set-output name=name::{expected}\n"
+
+    # Check that nothing written into stdout / stderr
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+    # But GITHUB_OUTPUT file contains proper context
+    assert github_output_path.read_text() == f"name<<EOF\n{expected}\nEOF\n"


### PR DESCRIPTION
To not use `::set-output ...` echoing into stdout in favor of writing to file from `GITHUB_OUTPUT` env var.

Fixes: #185
