### PR TITLE
build: Fix stable trove classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ packages = [
 ]
 keywords = ["changelog", "conventional commit", "bump", "version", "calver", "semver", "pre release"]
 classifiers = [
-  "Development Status :: 5 - Stable",
+  "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Intended Audience :: System Administrators",
   "Environment :: Console",


### PR DESCRIPTION
As it named `Development Status :: 5 - Production/Stable`, not just `Development Status :: 5 - Stable` :shrug:
