### PR TITLE
refactor: Drop attrs dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -44,25 +44,6 @@ files = [
 ]
 
 [[package]]
-name = "attrs"
-version = "22.2.0"
-description = "Classes Without Boilerplate"
-optional = false
-python-versions = ">=3.6"
-groups = ["main"]
-files = [
-    {file = "attrs-22.2.0-py3-none-any.whl", hash = "sha256:29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836"},
-    {file = "attrs-22.2.0.tar.gz", hash = "sha256:c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99"},
-]
-
-[package.extras]
-cov = ["attrs[tests]", "coverage-enable-subprocess", "coverage[toml] (>=5.3)"]
-dev = ["attrs[docs,tests]"]
-docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier", "zope.interface"]
-tests = ["attrs[tests-no-zope]", "zope.interface"]
-tests-no-zope = ["cloudpickle ; platform_python_implementation == \"CPython\"", "cloudpickle ; platform_python_implementation == \"CPython\"", "hypothesis", "hypothesis", "mypy (>=0.971,<0.990) ; platform_python_implementation == \"CPython\"", "mypy (>=0.971,<0.990) ; platform_python_implementation == \"CPython\"", "pympler", "pympler", "pytest (>=4.3.0)", "pytest (>=4.3.0)", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version < \"3.11\"", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version < \"3.11\"", "pytest-xdist[psutil]", "pytest-xdist[psutil]"]
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -646,4 +627,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "7b174a72ba1527054572750abcda2c8a90279a12c0416c05c2879cacb59cf026"
+content-hash = "4503bd34a3b39b81dfa189d6aa6096ce0e08c0326236aabf7959b9a5459eb689"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "attrs>=22.1.0,<23.0.0",
   "tomli>=1.2.0,<3.0.0; python_version<='3.11.0a6'",
 ]
 [project.scripts]
@@ -154,5 +153,5 @@ commands =
 [testenv:py310-minimum-requirements]
 commands_pre =
   poetry install --only main,test
-  python3 -m pip install attrs==22.1.0 tomli==1.2.0
+  python3 -m pip install tomli==1.2.0
 """

--- a/python.mk
+++ b/python.mk
@@ -47,6 +47,10 @@ ensure-venv: .python-version
 		$(POETRY) env use $$($(UV) python find $(PYTHON_VERSION)); \
 	fi
 
+.PHONY: install-pre-commit
+install-pre-commit: .python-version
+	$(PRE_COMMIT) install
+
 .PHONY: install-python
 install-python: .install-python
 .install-python: poetry.toml $(PYTHON_BIN) poetry.lock

--- a/src/badabump/changelog.py
+++ b/src/badabump/changelog.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-import datetime
+import dataclasses
 import logging
 import re
 from typing import TYPE_CHECKING, Union
 
-import attrs
-
+from badabump.datetimes import utcnow_naive
 from badabump.enums import ChangeLogTypeEnum, FormatTypeEnum
 
 if TYPE_CHECKING:
@@ -42,7 +41,7 @@ FORMATTED_COMMIT_WITH_PR_RE = re.compile(
 logger = logging.getLogger(__name__)
 
 
-@attrs.frozen(slots=True, kw_only=True)
+@dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
 class ConventionalCommit:
     raw_commit_type: str
     description: str
@@ -137,16 +136,22 @@ class ConventionalCommit:
         return None
 
 
-@attrs.frozen(slots=True, kw_only=True)
+@dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
 class ChangeLog:
     commits: tuple[ConventionalCommit, ...]
 
-    feature_commits: tuple[ConventionalCommit, ...] = attrs.field(init=False)
-    fix_commits: tuple[ConventionalCommit, ...] = attrs.field(init=False)
-    refactor_commits: tuple[ConventionalCommit, ...] = attrs.field(init=False)
-    other_commits: tuple[ConventionalCommit, ...] = attrs.field(init=False)
+    feature_commits: tuple[ConventionalCommit, ...] = dataclasses.field(
+        init=False
+    )
+    fix_commits: tuple[ConventionalCommit, ...] = dataclasses.field(init=False)
+    refactor_commits: tuple[ConventionalCommit, ...] = dataclasses.field(
+        init=False
+    )
+    other_commits: tuple[ConventionalCommit, ...] = dataclasses.field(
+        init=False
+    )
 
-    def __attrs_post_init__(self) -> None:
+    def __post_init__(self) -> None:
         feature_commits: list[ConventionalCommit] = []
         fix_commits: list[ConventionalCommit] = []
         refactor_commits: list[ConventionalCommit] = []
@@ -357,7 +362,7 @@ def version_header(
 ) -> str:
     content = version
     if include_date:
-        now = datetime.datetime.utcnow()
+        now = utcnow_naive()
         content = f"{version} ({now.date().isoformat()})"
 
     is_rst = format_type == FormatTypeEnum.rst

--- a/src/badabump/configs.py
+++ b/src/badabump/configs.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
+import dataclasses
 from pathlib import Path
 from typing import TYPE_CHECKING, Union
-
-import attrs
 
 from badabump import __app__
 from badabump.constants import (
@@ -31,15 +30,15 @@ if TYPE_CHECKING:
     from badabump.annotations import DictStrAny, T
 
 
-@attrs.frozen(slots=True, kw_only=True)
+@dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
 class ProjectConfig:
-    path: Path = attrs.Factory(Path.cwd)
+    path: Path = dataclasses.field(default_factory=Path.cwd)
 
     project_type: ProjectTypeEnum = DEFAULT_PROJECT_TYPE
 
     version_type: VersionTypeEnum = DEFAULT_VERSION_TYPE
     version_schema: str = DEFAULT_VERSION_SCHEMA
-    version_files: tuple[str, ...] = attrs.Factory(tuple)
+    version_files: tuple[str, ...] = dataclasses.field(default_factory=tuple)
 
     tag_format: str = DEFAULT_TAG_FORMAT
     tag_subject_format: str = DEFAULT_TAG_SUBJECT_FORMAT
@@ -58,7 +57,7 @@ class ProjectConfig:
     post_bump_hook: Union[str, None] = None
     strict_mode: bool = DEFAULT_STRICT_MODE
 
-    def __attrs_post_init__(self) -> None:
+    def __post_init__(self) -> None:
         if self.version_type == VersionTypeEnum.semver:
             object.__setattr__(self, "version_schema", DEFAULT_SEMVER_SCHEMA)
 
@@ -117,14 +116,14 @@ class ProjectConfig:
         )
 
 
-@attrs.frozen(slots=True, kw_only=True)
+@dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
 class UpdateConfig:
     is_breaking_change: bool = False
     is_minor_change: bool = False
     is_micro_change: bool = True
     is_pre_release: bool = False
 
-    def __attrs_post_init__(self) -> None:
+    def __post_init__(self) -> None:
         values = sorted(
             [
                 self.is_breaking_change,
@@ -134,8 +133,8 @@ class UpdateConfig:
         )
         if values != [False, False, True]:
             raise ValueError(
-                "Update config allow to be initialized only with one "
-                "breaking, minor, or micro change at a time."
+                "Update config allow to be initialized only with one"
+                " breaking, minor, or micro change at a time."
             )
 
 

--- a/src/badabump/datetimes.py
+++ b/src/badabump/datetimes.py
@@ -1,0 +1,11 @@
+import datetime
+
+UTC = datetime.timezone.utc
+
+
+def utcnow_naive() -> datetime.datetime:
+    """Replacement for now deprecated datetime.datetime.utcnow function.
+
+    To return current datetime at UTC timezone, but without TZ info (naive).
+    """
+    return datetime.datetime.now(UTC).replace(tzinfo=None)

--- a/src/badabump/git.py
+++ b/src/badabump/git.py
@@ -1,17 +1,16 @@
 from __future__ import annotations
 
+import dataclasses
 import subprocess
 from contextlib import suppress
 from typing import TYPE_CHECKING, Union
-
-import attrs
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
     from pathlib import Path
 
 
-@attrs.frozen(slots=True, kw_only=True)
+@dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
 class Git:
     path: Path
 

--- a/src/badabump/versions/calver.py
+++ b/src/badabump/versions/calver.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
 
-import datetime
+import dataclasses
 from typing import TYPE_CHECKING, Union
 
-import attrs
-
 from badabump.constants import DEFAULT_VERSION_SCHEMA
+from badabump.datetimes import utcnow_naive
 from badabump.versions.exceptions import VersionError, VersionParseError
 from badabump.versions.formatting import format_version
 from badabump.versions.parsing import parse_version
 
 if TYPE_CHECKING:
+    import datetime
+
     from typing_extensions import Self
 
     from badabump.annotations import DictStrAny, DictStrStr
@@ -50,7 +51,7 @@ SCHEMA_PARTS_PARSING = {
 }
 
 
-@attrs.frozen(slots=True, kw_only=True)
+@dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
 class CalVer:
     year: int
     month: Union[int, None] = None
@@ -84,7 +85,7 @@ class CalVer:
 
     @classmethod
     def initial(cls, *, schema: str) -> Self:
-        utcnow = datetime.datetime.utcnow()
+        utcnow = utcnow_naive()
         return cls(
             year=utcnow.year,
             month=utcnow.month,
@@ -103,10 +104,10 @@ class CalVer:
         raise VersionParseError(schema, value)
 
     def get_format_context(self) -> DictStrAny:
-        return {**attrs.asdict(self), "short_year": self.short_year}
+        return {**dataclasses.asdict(self), "short_year": self.short_year}
 
     def update(self, config: UpdateConfig) -> Self:
-        utcnow = datetime.datetime.utcnow()
+        utcnow = utcnow_naive()
 
         next_minor: Union[int, None] = None
         next_micro: Union[int, None] = None
@@ -157,7 +158,7 @@ class CalVer:
             if next_micro is not None and config.is_micro_change:
                 next_micro += 1
 
-        return attrs.evolve(
+        return dataclasses.replace(
             self,
             year=next_year,
             month=next_month,

--- a/src/badabump/versions/pre_release.py
+++ b/src/badabump/versions/pre_release.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
+import dataclasses
 from collections import defaultdict
 from contextlib import suppress
 from enum import Enum, unique
 from typing import TYPE_CHECKING, Union
-
-import attrs
 
 from badabump.enums import ProjectTypeEnum
 from badabump.versions.formatting import format_version
@@ -55,7 +54,7 @@ PRE_RELEASE_TYPE_MAPPING = {
 }
 
 
-@attrs.frozen(slots=True, kw_only=True)
+@dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
 class PreRelease:
     pre_release_type: PreReleaseTypeEnum = PreReleaseTypeEnum.alpha
     number: int = 0

--- a/src/badabump/versions/semver.py
+++ b/src/badabump/versions/semver.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
+import dataclasses
 from typing import TYPE_CHECKING, Union
-
-import attrs
 
 from badabump.constants import DEFAULT_SEMVER_SCHEMA as SCHEMA
 from badabump.versions.exceptions import VersionParseError
@@ -28,7 +27,7 @@ SCHEMA_PARTS_PARSING = {
 }
 
 
-@attrs.frozen(slots=True, kw_only=True)
+@dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
 class SemVer:
     major: int
     minor: int
@@ -60,7 +59,7 @@ class SemVer:
 
     def format(self) -> str:  # noqa: A003
         return format_version(
-            self.schema, SCHEMA_PARTS_FORMATTING, attrs.asdict(self)
+            self.schema, SCHEMA_PARTS_FORMATTING, dataclasses.asdict(self)
         )
 
     def update(self, config: UpdateConfig) -> Self:
@@ -68,11 +67,13 @@ class SemVer:
             return self
 
         if config.is_breaking_change:
-            return attrs.evolve(self, major=self.major + 1, minor=0, patch=0)
+            return dataclasses.replace(
+                self, major=self.major + 1, minor=0, patch=0
+            )
 
         if config.is_minor_change:
-            return attrs.evolve(
+            return dataclasses.replace(
                 self, major=self.major, minor=self.minor + 1, patch=0
             )
 
-        return attrs.evolve(self, patch=self.patch + 1)
+        return dataclasses.replace(self, patch=self.patch + 1)

--- a/src/badabump/versions/version.py
+++ b/src/badabump/versions/version.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
+import dataclasses
 import json
 from contextlib import suppress
 from typing import cast, TYPE_CHECKING, TypeAlias, Union
-
-import attrs
 
 from badabump.enums import ProjectTypeEnum, VersionTypeEnum
 from badabump.loaders import get_pyproject_toml_metadata, loads_toml
@@ -25,7 +24,7 @@ if TYPE_CHECKING:
     CalOrSemVer: TypeAlias = Union[CalVer, SemVer]
 
 
-@attrs.frozen(slots=True, kw_only=True)
+@dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
 class Version:
     version: CalOrSemVer
     pre_release: Union[PreRelease, None] = None
@@ -91,7 +90,7 @@ class Version:
 
     def enforce_pre_release(self, is_pre_release: bool) -> Self:
         if self.pre_release is None and is_pre_release:
-            return attrs.evolve(self, pre_release=PreRelease())
+            return dataclasses.replace(self, pre_release=PreRelease())
         return self
 
     def format(self, *, config: ProjectConfig) -> str:  # noqa: A003
@@ -114,7 +113,7 @@ class Version:
         if config.is_pre_release:
             return version_class(
                 version=self.version.update(
-                    attrs.evolve(config, is_pre_release=False)
+                    dataclasses.replace(config, is_pre_release=False)
                 ),
                 pre_release=PreRelease(),
             )

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1,5 +1,3 @@
-import datetime
-
 import pytest
 
 from badabump.changelog import (
@@ -8,6 +6,7 @@ from badabump.changelog import (
     ConventionalCommit,
     version_header,
 )
+from badabump.datetimes import utcnow_naive
 from badabump.enums import ChangeLogTypeEnum, FormatTypeEnum
 
 CI_BREAKING_COMMIT = "ci!: Use badabump release bot for pushing tags"
@@ -129,7 +128,7 @@ Other:
 - **BREAKING CHANGE:** Use badabump release bot for pushing tags
 - [#123] (**openapi**) Update descriptions in OpenAPI schema"""
 
-UTCNOW = datetime.datetime.utcnow()
+UTCNOW = utcnow_naive()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_versions_calver.py
+++ b/tests/test_versions_calver.py
@@ -1,12 +1,11 @@
-import datetime
-
 import pytest
 import time_machine
 
 from badabump.configs import UpdateConfig
+from badabump.datetimes import utcnow_naive
 from badabump.versions.calver import CalVer, SHORT_YEAR_START
 
-UTCNOW = datetime.datetime.utcnow()
+UTCNOW = utcnow_naive()
 
 YEAR = UTCNOW.year
 SHORT_YEAR = YEAR - SHORT_YEAR_START

--- a/tests/test_versions_version.py
+++ b/tests/test_versions_version.py
@@ -1,12 +1,12 @@
-import datetime
+import dataclasses
 import json
 from pathlib import Path
 
-import attrs
 import pytest
 import tomli_w
 
 from badabump.configs import ProjectConfig, UpdateConfig
+from badabump.datetimes import utcnow_naive
 from badabump.enums import ProjectTypeEnum, VersionTypeEnum
 from badabump.versions.calver import CalVer, SHORT_YEAR_START
 from badabump.versions.exceptions import VersionParseError
@@ -26,7 +26,7 @@ def test_find_project_version_javascript(tmpdir, version):
     tmp_path = Path(tmpdir)
     (tmp_path / "package.json").write_text(json.dumps({"version": version}))
 
-    config = attrs.evolve(
+    config = dataclasses.replace(
         SEMVER_PROJECT_CONFIG,
         path=tmp_path,
         project_type=ProjectTypeEnum.javascript,
@@ -48,7 +48,7 @@ def test_find_project_version_python(tmpdir, table_name: str, version: str):
     tmp_path = Path(tmpdir)
     (tmp_path / "pyproject.toml").write_text(tomli_w.dumps(data))
 
-    config = attrs.evolve(
+    config = dataclasses.replace(
         SEMVER_PROJECT_CONFIG,
         path=tmp_path,
         project_type=ProjectTypeEnum.python,
@@ -63,7 +63,7 @@ def test_find_project_version_python(tmpdir, table_name: str, version: str):
     "project_type", (ProjectTypeEnum.javascript, ProjectTypeEnum.python)
 )
 def test_find_project_version_empty(tmpdir, project_type):
-    config = attrs.evolve(SEMVER_PROJECT_CONFIG, path=Path(tmpdir))
+    config = dataclasses.replace(SEMVER_PROJECT_CONFIG, path=Path(tmpdir))
     assert find_project_version(config=config) is None
 
 
@@ -75,7 +75,7 @@ def test_find_project_version_empty(tmpdir, project_type):
     ),
 )
 def test_guess_initial_version(tmpdir, config, is_pre_release, expected):
-    tmp_config = attrs.evolve(config, path=Path(tmpdir))
+    tmp_config = dataclasses.replace(config, path=Path(tmpdir))
     assert (
         Version.guess_initial_version(
             config=tmp_config, is_pre_release=is_pre_release
@@ -230,7 +230,7 @@ def test_version_from_tag(tag, config, expected):
     ),
 )
 def test_version_update_calver(current_suffix, update_config, expected_suffix):
-    short_year = datetime.datetime.utcnow().year - SHORT_YEAR_START
+    short_year = utcnow_naive().year - SHORT_YEAR_START
 
     current = f"{short_year}.{current_suffix}"
     expected = f"{short_year}.{expected_suffix}"


### PR DESCRIPTION
As well as no longer call `datetime.datetime.utcnow` directly, as it
deprecated on recent Python versions. Instead call `utcnow_naive` helper
function, which returns current datetime at UTC timezone but without TZ
info (TZ-naive).
